### PR TITLE
fix: move gradient utility to /utils

### DIFF
--- a/src/components/quiz/QuizQuestion.tsx
+++ b/src/components/quiz/QuizQuestion.tsx
@@ -4,6 +4,7 @@ import { useCorrectness } from "../../context/CorrrectnessContext";
 import useCorrectnessCalculation from "../../hooks/quiz/useCorrectnessCalculations";
 import useAnswerState from "../../hooks/quiz/useAnswerState";
 import useShuffledGroupedAnswers from "../../hooks/quiz/useShuffledAnswers";
+import { getBackgroundGradient } from "../../utils/quiz-utils";
 
 interface AnswerOption {
   id: number;
@@ -47,24 +48,12 @@ const QuizQuestion: React.FC<QuizQuestionProps> = ({
     setCorrectness,
   });
 
-  const getBackgroundGradient = () => {
-    switch (Math.round(correctness)) {
-      case 100:
-        return "bg-gradient-correct";
-      case 75:
-        return "bg-gradient-75";
-      case 50:
-        return "bg-gradient-50";
-      case 25:
-        return "bg-gradient-25";
-      default:
-        return "bg-gradient-25";
-    }
-  };
+  // Get the background gradient based on correctness
+  const correctnessBgGradient = getBackgroundGradient(correctness);
 
   return (
     <section
-      className={`h-screen w-full mx-auto px-4 py-8 md:p-20 ${getBackgroundGradient()}`}
+      className={`h-screen w-full mx-auto px-4 py-8 md:p-20 ${correctnessBgGradient}`}
       aria-labelledby="quiz-question"
     >
       <header className="text-center">

--- a/src/utils/quiz-utils.ts
+++ b/src/utils/quiz-utils.ts
@@ -1,0 +1,12 @@
+export  const getBackgroundGradient = (correctness: number) => {
+  switch (Math.round(correctness)) {
+    case 100:
+      return "bg-gradient-correct";
+    case 75:
+      return "bg-gradient-75";
+    case 50:
+      return "bg-gradient-50";
+    default:
+      return "bg-gradient-25";
+  }
+};


### PR DESCRIPTION
## What's been done

- `fix:` Moved `getBackgroundGradient` function to the new `/utils` folder for consistency and maintainability .
- `fix:` Removed the `case 25` in favour for `default` in the switch statement.