### PR TITLE
rf: replace ternary with a switch statement

### DIFF
--- a/src/components/quiz/AnswerToggle.tsx
+++ b/src/components/quiz/AnswerToggle.tsx
@@ -13,7 +13,7 @@ const NO_SELECTION = 0;
 interface AnswerOption {
   id: number;
   label: string;
-  correct: boolean; 
+  correct: boolean;
 }
 
 interface AnswerToggleProps {
@@ -61,19 +61,26 @@ const AnswerToggle: React.FC<AnswerToggleProps> = ({
   );
 
   const twoAnswerToggle = selectedIndex * 100;
-  const threeAnswerToggle =
-    selectedIndex === 0
-      ? FIRST_ANSWER
-      : selectedIndex === 1
-      ? SECOND_ANSWER
-      : THIRD_ANSWER;
+
+  const getThreeAnswerToggle = (selectedIndex: number): number => {
+    switch (selectedIndex) {
+      case 0:
+        return FIRST_ANSWER;
+      case 1:
+        return SECOND_ANSWER;
+      case 2:
+        return THIRD_ANSWER;
+      default:
+        return NO_SELECTION;
+    }
+  };
 
   const translatePercentage =
     selectedIndex === -1
       ? NO_SELECTION
       : answers.length === 2
       ? twoAnswerToggle
-      : threeAnswerToggle;
+      : getThreeAnswerToggle(selectedIndex);
 
   const handleKeyDown = (
     e: React.KeyboardEvent<HTMLLabelElement>,
@@ -121,10 +128,10 @@ const AnswerToggle: React.FC<AnswerToggleProps> = ({
             className="relative z-10 flex-1 cursor-pointer text-center"
             style={{ flexBasis: answerWidth }}
             tabIndex={0}
-            role="radio" 
-            aria-checked={selectedAnswer === answer.id} 
-            onKeyDown={(e) => handleKeyDown(e, answer.id)} 
-            onClick={() => handleSelect(answer.id)} 
+            role="radio"
+            aria-checked={selectedAnswer === answer.id}
+            onKeyDown={(e) => handleKeyDown(e, answer.id)}
+            onClick={() => handleSelect(answer.id)}
           >
             <input
               type="radio"

--- a/src/components/quiz/QuizQuestion.tsx
+++ b/src/components/quiz/QuizQuestion.tsx
@@ -4,6 +4,7 @@ import { useCorrectness } from "../../context/CorrrectnessContext";
 import useCorrectnessCalculation from "../../hooks/quiz/useCorrectnessCalculations";
 import useAnswerState from "../../hooks/quiz/useAnswerState";
 import useShuffledGroupedAnswers from "../../hooks/quiz/useShuffledAnswers";
+import { getBackgroundGradient } from "../../utils/quiz-utils";
 
 interface AnswerOption {
   id: number;
@@ -47,24 +48,12 @@ const QuizQuestion: React.FC<QuizQuestionProps> = ({
     setCorrectness,
   });
 
-  const getBackgroundGradient = () => {
-    switch (Math.round(correctness)) {
-      case 100:
-        return "bg-gradient-correct";
-      case 75:
-        return "bg-gradient-75";
-      case 50:
-        return "bg-gradient-50";
-      case 25:
-        return "bg-gradient-25";
-      default:
-        return "bg-gradient-25";
-    }
-  };
+  // Get the background gradient based on correctness
+  const correctnessBgGradient = getBackgroundGradient(correctness);
 
   return (
     <section
-      className={`h-screen w-full mx-auto px-4 py-8 md:p-20 ${getBackgroundGradient()}`}
+      className={`h-screen w-full mx-auto px-4 py-8 md:p-20 ${correctnessBgGradient}`}
       aria-labelledby="quiz-question"
     >
       <header className="text-center">

--- a/src/utils/quiz-utils.ts
+++ b/src/utils/quiz-utils.ts
@@ -1,0 +1,12 @@
+export  const getBackgroundGradient = (correctness: number) => {
+  switch (Math.round(correctness)) {
+    case 100:
+      return "bg-gradient-correct";
+    case 75:
+      return "bg-gradient-75";
+    case 50:
+      return "bg-gradient-50";
+    default:
+      return "bg-gradient-25";
+  }
+};


### PR DESCRIPTION
## What's been done

- `fix:` Replaced ternary operator with a switch statement for better readability. 

**Note:** This function can be moved to the `/utils` after PR #1 is merged.