### PR TITLE
fix: enhance answer shuffling Logic and optimise correctness checking with Set

### DIFF
--- a/src/components/quiz/AnswerToggle.tsx
+++ b/src/components/quiz/AnswerToggle.tsx
@@ -21,6 +21,7 @@ interface AnswerToggleProps {
   onAnswerChange: (isCorrect: boolean, answerId: number) => void;
   isLocked: (answerId: number) => boolean;
   correctnessScore: number;
+  correctAnswerIds: Set<number>;
 }
 
 const AnswerToggle: React.FC<AnswerToggleProps> = ({
@@ -28,13 +29,15 @@ const AnswerToggle: React.FC<AnswerToggleProps> = ({
   onAnswerChange,
   isLocked,
   correctnessScore,
+  correctAnswerIds,
 }) => {
   const isWrapped = useIsWrapped(answers, MAX_WIDTH_MOBILE);
 
   const { selectedAnswer, handleSelect } = useAnswerSelection(
     answers,
     isLocked,
-    onAnswerChange
+    onAnswerChange,
+    correctAnswerIds
   );
 
   // Color based on correctness score
@@ -121,10 +124,10 @@ const AnswerToggle: React.FC<AnswerToggleProps> = ({
             className="relative z-10 flex-1 cursor-pointer text-center"
             style={{ flexBasis: answerWidth }}
             tabIndex={0}
-            role="radio" 
-            aria-checked={selectedAnswer === answer.id} 
-            onKeyDown={(e) => handleKeyDown(e, answer.id)} 
-            onClick={() => handleSelect(answer.id)} 
+            role="radio"
+            aria-checked={selectedAnswer === answer.id}
+            onKeyDown={(e) => handleKeyDown(e, answer.id)}
+            onClick={() => handleSelect(answer.id)}
           >
             <input
               type="radio"

--- a/src/components/quiz/QuizQuestion.tsx
+++ b/src/components/quiz/QuizQuestion.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import AnswerToggle from "./AnswerToggle";
 import { useCorrectness } from "../../context/CorrrectnessContext";
 import useCorrectnessCalculation from "../../hooks/quiz/useCorrectnessCalculations";
@@ -29,9 +29,16 @@ const QuizQuestion: React.FC<QuizQuestionProps> = ({
     randomized
   );
 
-  const totalCorrectAnswers = shuffledGroupedAnswers
-    .flat()
-    .filter((answer) => answer.correct).length;
+  const correctAnswerIds = useMemo(() => {
+    return new Set(
+      shuffledGroupedAnswers
+        .flat()
+        .filter((answer) => answer.correct)
+        .map((answer) => answer.id) // Extract the IDs
+    );
+  }, [shuffledGroupedAnswers]);
+
+  const totalCorrectAnswers = correctAnswerIds.size;
 
   const {
     selectedAnswers,
@@ -88,6 +95,7 @@ const QuizQuestion: React.FC<QuizQuestionProps> = ({
               handleAnswerChange(isCorrect, answerId)
             }
             isLocked={(answerId: number) => lockedAnswers.includes(answerId)}
+            correctAnswerIds={correctAnswerIds}
           />
         ))}
       </fieldset>

--- a/src/hooks/quiz/useAnswerSelection.ts
+++ b/src/hooks/quiz/useAnswerSelection.ts
@@ -3,16 +3,15 @@ import { useEffect, useState } from "react";
 const useAnswerSelection = (
   answers: { id: number; correct: boolean }[],
   isLocked: (answerId: number) => boolean,
-  onAnswerChange: (isCorrect: boolean, answerId: number) => void
+  onAnswerChange: (isCorrect: boolean, answerId: number) => void,
+  correctAnswerIds: Set<number>
 ) => {
   const [selectedAnswer, setSelectedAnswer] = useState<number | null>(null);
   const [groupLocked, setGroupLocked] = useState(false);
 
   useEffect(() => {
     if (selectedAnswer !== null) {
-      const isCorrect = answers.find(
-        (answer) => answer.id === selectedAnswer
-      )?.correct;
+      const isCorrect = correctAnswerIds.has(selectedAnswer);
 
       if (isCorrect) {
         setGroupLocked(true); // Lock the group if the correct answer is selected

--- a/src/hooks/quiz/useShuffledAnswers.ts
+++ b/src/hooks/quiz/useShuffledAnswers.ts
@@ -15,16 +15,22 @@ const useShuffledGroupedAnswers = (
   const [shuffledGroupedAnswers, setShuffledGroupedAnswers] =
     useState<GroupedAnswerArray>(groupedAnswers);
 
+  // The Fisher-Yates algorithm ensures unbiased shuffling and runs in O(n)
   const shuffleArray = <T>(array: T[]): T[] => {
-    return array
-      .map((item) => ({ item, sortKey: Math.random() }))
-      .sort((a, b) => a.sortKey - b.sortKey)
-      .map(({ item }) => item);
+    const shuffledArray = [...array];
+    for (let i = shuffledArray.length - 1; i > 0; i--) {
+      const randomIndex = Math.floor(Math.random() * (i + 1));
+      [shuffledArray[i], shuffledArray[randomIndex]] = [
+        shuffledArray[randomIndex],
+        shuffledArray[i],
+      ];
+    }
+    return shuffledArray;
   };
 
   useEffect(() => {
     if (randomized) {
-      // Shuffle the order 
+      // Shuffle the order
       const shuffledAnswers = groupedAnswers.map((group) =>
         shuffleArray(group)
       );


### PR DESCRIPTION
## What's been done

- `fix:` Updated the `useShuffledGroupedAnswers` hook to use the [Fisher-Yates algorithm](https://www.geeksforgeeks.org/shuffle-a-given-array-using-fisher-yates-shuffle-algorithm/) for shuffling both the answers and grouped answers. This method offers an O(n) time complexity, making it more efficient and unbiased compared to the previous random sort method.
- `fix:` Refactored the `useAnswerSelection` hook to use a Set for checking correctness, making correctness checks more efficient compared to iterating through arrays.